### PR TITLE
chore: Handle zip file automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,6 @@ Arguments:
 --source
   The source Zip file that was downloaded from Twitter.
 
---expanded
-  Use if the source is actually an already-expanded Twitter zip file.
-
 --expandUrls
   Enabled by default. Will replace all "t.co" URLs in Tweet text with
   the actual URL the link was pointing to.
@@ -55,8 +52,8 @@ Arguments:
 
 --dev
   Run a web server that live updates for easier template development.
-
-
+  
+  
 ```
 
 ## Using your own templates

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ twitter-preserver --source=path/to/archive.zip
 Arguments:
 
 --source
-  The source Zip file that was downloaded from Twitter.
+  The source Zip file or an expanded Zip file that was downloaded from Twitter.
 
 --expandUrls
   Enabled by default. Will replace all "t.co" URLs in Tweet text with

--- a/cmd.js
+++ b/cmd.js
@@ -9,7 +9,6 @@ import helpOutput from './src/help.js'
 
 const {
   source,
-  expanded,
   output,
   pdf,
   templates,
@@ -21,7 +20,6 @@ const {
 } = commandLineArgs([
   { name: 'source', alias: 's', type: String, defaultOption: true },
   { name: 'output', alias: 'o', type: String, defaultValue: './public' },
-  { name: 'expanded', alias: 'e', type: Boolean, defaultValue: false },
   { name: 'pdf', alias: 'p', type: Boolean, defaultValue: false },
   { name: 'dev', alias: 'd', type: Boolean, defaultValue: false },
   {
@@ -54,7 +52,7 @@ const includedData = include.split(',').map((item) => item.trim().toLowerCase())
     console.log(helpOutput())
     return
   }
-  unzip(source, expanded)
+  unzip(source)
     .then((path) =>
       build({
         source: path,
@@ -67,7 +65,7 @@ const includedData = include.split(',').map((item) => item.trim().toLowerCase())
       }),
     )
     .then((path) => {
-      if (!expanded) {
+      if (!path !== source) {
         return cleanup(path)
       }
       return

--- a/src/help.js
+++ b/src/help.js
@@ -6,7 +6,7 @@ twitter-preserver --source=path/to/archive.zip
 Arguments:
 
 --source
-  The source Zip file that was downloaded from Twitter.
+  The source Zip file or an expanded Zip file that was downloaded from Twitter.
 
 --expandUrls
   Enabled by default. Will replace all "t.co" URLs in Tweet text with

--- a/src/help.js
+++ b/src/help.js
@@ -8,9 +8,6 @@ Arguments:
 --source
   The source Zip file that was downloaded from Twitter.
 
---expanded
-  Use if the source is actually an already-expanded Twitter zip file.
-
 --expandUrls
   Enabled by default. Will replace all "t.co" URLs in Tweet text with
   the actual URL the link was pointing to.

--- a/src/unzip.js
+++ b/src/unzip.js
@@ -1,29 +1,34 @@
+import fs from 'fs/promises'
 import extract from 'extract-zip'
 import crypto from 'crypto'
 import ora from 'ora'
 import chalk from 'chalk'
 
-export default (source, expanded) =>
+export default (source) =>
   new Promise((resolve, reject) => {
     const spinner = ora({
       spinner: 'boxBounce',
-      text: 'Extracting Twitter zip file',
+      text: 'Loading Twitter archive',
     }).start()
-    if (expanded) {
-      spinner.stopAndPersist({
-        symbol: chalk.green('✔️'),
-        text: 'Loaded Twitter archive',
+
+    fs.lstat(source).then((stat) => {
+      if (stat.isDirectory()) {
+        spinner.stopAndPersist({
+          symbol: chalk.green('✔️'),
+          text: 'Loaded Twitter archive',
+        })
+        resolve(source)
+        return
+      }
+      spinner.text = 'Un-zipping Twitter archive'
+      const hash = crypto.createHash('md5').update(source).digest('hex')
+      const path = `/tmp/${Date.now()}-${hash}`
+      extract(source, { dir: path }).then((result) => {
+        spinner.stopAndPersist({
+          symbol: chalk.green('✔️'),
+          text: 'Extracted Twitter archive ZIP file',
+        })
+        resolve(path)
       })
-      resolve(source)
-      return
-    }
-    const hash = crypto.createHash('md5').update(source).digest('hex')
-    const path = `/tmp/${Date.now()}-${hash}`
-    extract(source, { dir: path }).then((result) => {
-      spinner.stopAndPersist({
-        symbol: chalk.green('✔️'),
-        text: 'Extracted ZIP file',
-      })
-      resolve(path)
     })
   })


### PR DESCRIPTION
Fixes #9. Removes the `--expanded` command in favor of just `stat`ing the source input.